### PR TITLE
Fix LogViewer fallback for deprecated `logId` input

### DIFF
--- a/nebula-logger/core/main/log-management/lwc/logViewer/__tests__/logViewer.test.js
+++ b/nebula-logger/core/main/log-management/lwc/logViewer/__tests__/logViewer.test.js
@@ -54,6 +54,16 @@ describe('Logger JSON Viewer lwc tests', () => {
     expect(logViewerElement.title).toEqual(MOCK_GET_LOG.log.Name);
   });
 
+  it('uses deprecated logId when recordId is not set', async () => {
+    const logViewerElement = createElement('c-log-viewer', { is: LogViewer });
+    logViewerElement.logId = 'a0A000000000123';
+    document.body.appendChild(logViewerElement);
+
+    await Promise.resolve('resolves wire config update');
+
+    expect(getLog.getLastConfig()).toEqual({ logId: 'a0A000000000123' });
+  });
+
   it('defaults to brand button variant', async () => {
     const logViewer = createElement('c-log-viewer', { is: LogViewer });
     document.body.appendChild(logViewer);

--- a/nebula-logger/core/main/log-management/lwc/logViewer/logViewer.js
+++ b/nebula-logger/core/main/log-management/lwc/logViewer/logViewer.js
@@ -29,7 +29,11 @@ export default class LogViewer extends LightningElement {
   _logFileContent;
   _logJSONContent;
 
-  @wire(getLog, { logId: '$recordId' })
+  get effectiveLogId() {
+    return this.recordId || this.logId;
+  }
+
+  @wire(getLog, { logId: '$effectiveLogId' })
   wiredGetLog(result) {
     if (result.data) {
       const reconstructedLog = JSON.parse(JSON.stringify(result.data.log));


### PR DESCRIPTION
### Motivation

- Restore backward compatibility when `c/logViewer` is rendered with the deprecated `logId` input so the Apex wire adapter receives a valid ID.

### Description

- Add an `effectiveLogId` getter that resolves to `recordId || logId` and wire `getLog` to `'$effectiveLogId'` in `nebula-logger/core/main/log-management/lwc/logViewer/logViewer.js`.
- Add a Jest regression test that renders the component with only `logId` set and asserts the wire adapter received the expected config in `nebula-logger/core/main/log-management/lwc/logViewer/__tests__/logViewer.test.js`.

### Testing

- Ran the LWC tests with `npm run test:lwc:nocoverage` and the full suite passed (15 test suites, all LWC tests succeeded), including the new `logViewer` test.
- Ran the focused `logViewer` test file and verified the new test case passes as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a83eb2ec7483278937618aaa9dcc76)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Log viewer now properly supports logId parameter as a fallback when recordId is not provided, ensuring backward compatibility.

* **Tests**
  * Added test coverage for logId parameter fallback functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->