### PR TITLE
test: mock lightning/datatable wrapTableHeader in jest

### DIFF
--- a/config/jest/mocks/lightning/datatable.js
+++ b/config/jest/mocks/lightning/datatable.js
@@ -1,0 +1,6 @@
+import { api } from 'lwc';
+import LightningDatatable from '@salesforce/sfdx-lwc-jest/src/lightning-stubs/datatable/datatable';
+
+export default class Datatable extends LightningDatatable {
+  @api wrapTableHeader;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,8 @@ module.exports = {
   coverageDirectory: './test-coverage/lwc',
   moduleNameMapper: {
     '^lightning/empApi$': '<rootDir>/config/jest/mocks/lightning/empApi',
-    '^lightning/navigation$': '<rootDir>/config/jest/mocks/lightning/navigation'
+    '^lightning/navigation$': '<rootDir>/config/jest/mocks/lightning/navigation',
+    '^lightning/datatable$': '<rootDir>/config/jest/mocks/lightning/datatable'
   },
   // modulePathIgnorePatterns: ['recipes'],
   testPathIgnorePatterns: ['<rootDir>/temp/']


### PR DESCRIPTION
### Motivation
- Unit tests produced repeated LWC runtime warnings for an unknown `wrapTableHeader` public property used on `<lightning-datatable>` in `loggerSettings`, causing noisy test output and potential confusion. 
- The upstream `sfdx-lwc-jest` datatable stub does not declare the `wrapTableHeader` property, so a local mock was required to reflect the component usage in tests.

### Description
- Added a custom Jest mock `config/jest/mocks/lightning/datatable.js` that extends the `@salesforce/sfdx-lwc-jest` datatable stub and declares `@api wrapTableHeader` so tests recognize the attribute. 
- Updated `jest.config.js` `moduleNameMapper` to map `^lightning/datatable$` to the new mock so imports of `lightning/datatable` use the patched stub automatically.

### Testing
- Ran the focused test: `npx sfdx-lwc-jest --skipApiVersionCheck -- nebula-logger/core/main/log-management/lwc/loggerSettings/__tests__/loggerSettings.test.js`, which passed. 
- Ran the full LWC test suite: `npm run test:lwc:nocoverage`, which completed successfully with all LWC tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcce3b44d083278eeb78ad880a3726)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Jest mock for Lightning Datatable component to enable proper testing of components that depend on this feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->